### PR TITLE
refactor install process

### DIFF
--- a/Configure.cpp
+++ b/Configure.cpp
@@ -28,6 +28,10 @@
 #define CFG_DIR "/tmp/"
 #endif
 
+#ifndef DOT_DIR
+#define DOT_DIR "$HOME/.mvoice/"
+#endif
+
 void CConfigure::SetDefaultValues()
 {
 	// M17
@@ -43,7 +47,7 @@ void CConfigure::SetDefaultValues()
 
 void CConfigure::ReadData()
 {
-	std::string path(CFG_DIR);
+	std::string path(DOT_DIR);
 	path.append("mvoice.cfg");
 
 	std::ifstream cfg(path.c_str(), std::ifstream::in);
@@ -92,7 +96,7 @@ void CConfigure::ReadData()
 void CConfigure::WriteData()
 {
 
-	std::string path(CFG_DIR);
+	std::string path(DOT_DIR);
 	path.append("mvoice.cfg");
 
 	// directory exists, now make the file

--- a/M17Gateway.cpp
+++ b/M17Gateway.cpp
@@ -27,10 +27,6 @@
 
 #include "M17Gateway.h"
 
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
-
 #ifndef DOT_DIR
 #define DOT_DIR "$HOME/.mvoice"
 #endif

--- a/M17Gateway.cpp
+++ b/M17Gateway.cpp
@@ -31,6 +31,10 @@
 #define CFG_DIR "/tmp/"
 #endif
 
+#ifndef DOT_DIR
+#define DOT_DIR "$HOME/.mvoice"
+#endif
+
 CM17Gateway::CM17Gateway() : CBase()
 {
 	keep_running = false; // not running initially. this will be set to true in CMainWindow
@@ -46,7 +50,7 @@ CM17Gateway::~CM17Gateway()
 bool CM17Gateway::Init(const CFGDATA &cfgdata)
 {
 	mlink.state = ELinkState::unlinked;
-	std::string path(CFG_DIR);
+	std::string path(DOT_DIR);
 	path.append("qn.db");
 	if (qnDB.Open(path.c_str()))
 		return true;

--- a/M17RouteMap.cpp
+++ b/M17RouteMap.cpp
@@ -26,6 +26,10 @@
 #define CFG_DIR "/tmp/"
 #endif
 
+#ifndef DOT_DIR
+#define DOT_DIR "$HOME/.mvoice/"
+#endif
+
 CM17RouteMap::~CM17RouteMap()
 {
 	mux.lock();

--- a/M17RouteMap.cpp
+++ b/M17RouteMap.cpp
@@ -22,10 +22,6 @@
 #include "M17RouteMap.h"
 #include "Utilities.h"
 
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
-
 #ifndef DOT_DIR
 #define DOT_DIR "$HOME/.mvoice/"
 #endif

--- a/M17RouteMap.cpp
+++ b/M17RouteMap.cpp
@@ -92,7 +92,7 @@ void CM17RouteMap::ReadJson(const char *filename)
 	bool cs, ur, v4, v6, po;
 	cs = ur = v4 = v6 = po = false;
 	std::string scs, sur, sv4, sv6, spo;
-	std::string path(CFG_DIR);
+	std::string path(DOT_DIR);
 	path.append(filename);
 	std::ifstream f(path, std::ifstream::in);
 	while (f.good()) {
@@ -133,7 +133,7 @@ void CM17RouteMap::ReadJson(const char *filename)
 
 void CM17RouteMap::Read(const char *filename)
 {
-	std::string path(CFG_DIR);
+	std::string path(DOT_DIR);
 	path.append(filename);
 	std::ifstream file(path, std::ifstream::in);
 	if (file.is_open()) {
@@ -151,7 +151,7 @@ void CM17RouteMap::Read(const char *filename)
 
 void CM17RouteMap::Save() const
 {
-	std::string path(CFG_DIR);
+	std::string path(DOT_DIR);
 	path.append("M17Hosts.cfg");
 	std::ofstream file(path.c_str(), std::ofstream::out | std::ofstream::trunc);
 	if (file.is_open()) {

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -37,6 +37,10 @@
 #define CFG_DIR "/tmp/"
 #endif
 
+#ifndef DOT_DIR
+#define DOT_DIR "$HOME/.mvoice/"
+#endif
+
 static Glib::RefPtr<Gtk::Application> theApp;
 
 CMainWindow::CMainWindow() :
@@ -108,7 +112,7 @@ void CMainWindow::CloseAll()
 
 bool CMainWindow::Init(const Glib::RefPtr<Gtk::Builder> builder, const Glib::ustring &name)
 {
-	std::string dbname(CFG_DIR);
+	std::string dbname(DOT_DIR);
 	dbname.append("qn.db");
 	if (qnDB.Open(dbname.c_str()))
 		return true;
@@ -596,7 +600,7 @@ static void ReadM17Json()
 {
 	curl_global_init(CURL_GLOBAL_ALL);
 
-	std::string path(CFG_DIR);
+	std::string path(DOT_DIR);
 	path.append("m17refl.json");
 	std::ofstream ofs(path);
 	if (ofs.is_open()) {
@@ -615,6 +619,15 @@ static void ReadM17Json()
 
 int main (int argc, char **argv)
 {
+
+	//Create dotfolder
+	struct stat st = {0};
+
+	if (stat(DOT_DIR, &st) == -1)
+	{
+		mkdir (DOT_DIR, 0755);
+	}
+
 	ReadM17Json();
 
 	theApp = Gtk::Application::create(argc, argv, "net.openquad.DVoice");

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 # Copyright (c) 2019-2020 by Thomas A. Early N7TAE
-CFGDIR = $(HOME)/etc/
-BINDIR = $(HOME)/bin/
+CFGDIR = /usr/local/etc/
+BINDIR = /usr/local/bin/
+DOTDIR = $(HOME)/.mvoice/
 
 # choose this if you want debugging help
 #CPPFLAGS=-ggdb -W -Wall -std=c++11 -Icodec2 -DCFG_DIR=\"$(CFGDIR)\" `pkg-config --cflags gtkmm-3.0`
 # or, you can choose this for a smaller executable without debugging help
-CPPFLAGS=-W -Wall -std=c++11 -Icodec2 -DCFG_DIR=\"$(CFGDIR)\" `pkg-config --cflags gtkmm-3.0`
+CPPFLAGS=-W -Wall -std=c++11 -Icodec2 -DCFG_DIR=\"$(CFGDIR)\" -DDOT_DIR=\"$(DOTDIR)\" `pkg-config --cflags gtkmm-3.0`
 
 EXE = mvoice
 SRCS = $(wildcard *.cpp) $(wildcard codec2/*.cpp)
@@ -27,7 +28,7 @@ clean :
 
 install : $(EXE)
 	mkdir -p $(CFGDIR)
-	/bin/ln -f $(shell pwd)/MVoice.glade $(CFGDIR)
+	/bin/cp -f $(shell pwd)/MVoice.glade $(CFGDIR)
 	mkdir -p $(BINDIR)
 	/bin/cp -f $(EXE) $(BINDIR)
 
@@ -35,9 +36,7 @@ uninstall :
 	/bin/rm -rf $(CFGDIR)announce
 	/bin/rm -f $(CFGDIR)MVoice.glade
 	/bin/rm -f $(CFGDIR)$(EXE).cfg
-	/bin/rm -f $(CFGDIR)qn.db
 	/bin/rm -f $(CFGDIR)mvoice.cfg
-	/bin/rm -f $(CFGDIR)m17refl.json
 	/bin/rm -f $(BINDIR)$(EXE)
 
 #interactive :

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOTDIR = $(HOME)/.mvoice/
 # choose this if you want debugging help
 #CPPFLAGS=-ggdb -W -Wall -std=c++11 -Icodec2 -DCFG_DIR=\"$(CFGDIR)\" `pkg-config --cflags gtkmm-3.0`
 # or, you can choose this for a smaller executable without debugging help
-CPPFLAGS=-W -Wall -std=c++11 -Icodec2 -DCFG_DIR=\"$(CFGDIR)\" -DDOT_DIR=\"$(DOTDIR)\" `pkg-config --cflags gtkmm-3.0`
+CPPFLAGS=-W -Wno-missing-field-initializers -std=c++11 -Icodec2 -DCFG_DIR=\"$(CFGDIR)\" -DDOT_DIR=\"$(DOTDIR)\" `pkg-config --cflags gtkmm-3.0`
 
 EXE = mvoice
 SRCS = $(wildcard *.cpp) $(wildcard codec2/*.cpp)
@@ -33,10 +33,7 @@ install : $(EXE)
 	/bin/cp -f $(EXE) $(BINDIR)
 
 uninstall :
-	/bin/rm -rf $(CFGDIR)announce
 	/bin/rm -f $(CFGDIR)MVoice.glade
-	/bin/rm -f $(CFGDIR)$(EXE).cfg
-	/bin/rm -f $(CFGDIR)mvoice.cfg
 	/bin/rm -f $(BINDIR)$(EXE)
 
 #interactive :

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ If it builds okay, then you can install it:
 sudo make install
 ```
 
-All the configuration files are located in ~/etc and the mvoice executable is in ~/bin. Please note that symbolic links are installed, so you can do a `make clean` to get rid of the intermediate object files, but don't delete the build directory because that's the only way to remove *mvoice* from your system:
+All the configuration files are located in ~/.mvoice and the mvoice executable is in /usr/local/bin. Please note that symbolic links are installed, so you can do a `make clean` to get rid of the intermediate object files, but don't delete the build directory because that's the only way to remove *mvoice* from your system:
+
 
 ```bash
 make uninstall

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ make
 If it builds okay, then you can install it:
 
 ```bash
-make install
+sudo make install
 ```
 
 All the configuration files are located in ~/etc and the mvoice executable is in ~/bin. Please note that symbolic links are installed, so you can do a `make clean` to get rid of the intermediate object files, but don't delete the build directory because that's the only way to remove *mvoice* from your system:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ All the configuration files are located in ~/etc and the mvoice executable is in
 make uninstall
 ```
 
+For a complete uninstall, also remove the .mvoice folder from your home directory:
+
+```bash
+cd ~
+rm -rf .mvoice
+```
+
 ### Special comments only for the Raspberry Pi
 
 If you want a desktop icon to launch *mvoice* then, from your build directory:

--- a/mvoice.desktop
+++ b/mvoice.desktop
@@ -4,6 +4,6 @@ Encoding=UTF-8
 Name=MVoice
 Comment=MVoice by N7TAE
 Icon=/usr/share/icons/gnome/32x32/devices/audio-headset.png
-Exec=/home/pi/bin/mvoice
+Exec=/usr/local/bin/mvoice
 Terminal=true
 Categories=Ham Radio;


### PR DESCRIPTION
This is a refactor of the install process to make it more *nix-like, placing glade and binary into /usr/local folders, and user config files into ~/.mvoice - reflector list, user config, and qn.db persist through source updates and uninstalls. Config files can be removed by deleting ~/.mvoice

This satisfies requests by @g4klx and @nostar.