### PR TITLE
Fixed hangup of Settings window when there was an audio device withouut description (or name)

### DIFF
--- a/SettingsDlg.cpp
+++ b/SettingsDlg.cpp
@@ -205,11 +205,14 @@ void CSettingsDlg::on_AudioRescanButton_clicked()
 	refAudioOutListModel->clear();
 	while (*n != NULL) {
 		char *name = snd_device_name_get_hint(*n, "NAME");
-		if (NULL == name)
+		if (NULL == name) {
+			n++;
 			continue;
+		}
 		char *desc = snd_device_name_get_hint(*n, "DESC");
 		if (NULL == desc) {
 			free(name);
+			n++;
 			continue;
 		}
 


### PR DESCRIPTION
Clicking Settings in mvoice makes it hang on my machine. Investigation showed that I have two ALSA devices in ~/.asoundrc with no description, which makes mvoice loop trying to read the name and description of the same device forever. This simple fix fixes the problem.