### PR TITLE
use Gtk resource and config location

### DIFF
--- a/AudioManager.cpp
+++ b/AudioManager.cpp
@@ -30,10 +30,6 @@
 #include "codec2.h"
 #include "Callsign.h"
 
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
-
 CAudioManager::CAudioManager() : hot_mic(false), play_file(false), m17_sid_in(0U)
 {
 	link_open = true;
@@ -43,7 +39,7 @@ CAudioManager::CAudioManager() : hot_mic(false), play_file(false), m17_sid_in(0U
 bool CAudioManager::Init(CMainWindow *pMain)
 {
 	pMainWindow = pMain;
-	std::string index(CFG_DIR);
+	std::string index = Glib::get_user_config_dir() + G_DIR_SEPARATOR_S + "mvoice";
 
 	AM2M17.SetUp("am2m17");
 	LogInput.SetUp("log_input");

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.7.2)
+project(mvoice LANGUAGES CXX VERSION 0.0.1.0)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+include(GNUInstallDirs)
+
+#select the release build type by default to get optimization flags
+if(NOT CMAKE_BUILD_TYPE)
+   set(CMAKE_BUILD_TYPE "Release")
+   message(STATUS "Build type not specified: defaulting to release.")
+endif()
+
+#option (PREFER_CONVENIENCE_COPIES
+#        "Use local copies instead of system-wide version" ON)
+#find_package(Codec2)
+
+find_package(ALSA)
+find_package(PkgConfig)
+pkg_check_modules(GTKMM REQUIRED gtkmm-3.0 IMPORTED_TARGET)
+pkg_check_modules(Curl REQUIRED libcurl IMPORTED_TARGET)
+find_package(Threads REQUIRED)
+
+add_custom_command(OUTPUT resources.cpp
+  COMMAND glib-compile-resources
+          --sourcedir="${CMAKE_CURRENT_SOURCE_DIR}"
+          "${CMAKE_CURRENT_SOURCE_DIR}/mvoice.gresources.xml"
+          --target=resources.cpp --generate-source
+  COMMENT "compile resources")
+
+add_executable (mvoice
+  codec2/codebooks.cpp
+  codec2/codec2.cpp
+  codec2/kiss_fft.cpp
+  codec2/lpc.cpp
+  codec2/nlp.cpp
+  codec2/pack.cpp
+  codec2/qbase.cpp
+  codec2/quantise.cpp
+  AboutDlg.cpp
+  AudioManager.cpp
+  Base.cpp
+  Callsign.cpp
+  Configure.cpp
+  CRC.cpp
+  M17Gateway.cpp
+  M17RouteMap.cpp
+  MainWindow.cpp
+  SettingsDlg.cpp
+  UDPSocket.cpp
+  UnixDgramSocket.cpp
+  WaitCursor.cpp
+  resources.cpp
+  )
+
+target_include_directories(mvoice PRIVATE codec2)
+target_link_libraries(mvoice
+  PkgConfig::GTKMM ALSA::ALSA PkgConfig::Curl Threads::Threads)
+install(TARGETS mvoice RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/Configure.cpp
+++ b/Configure.cpp
@@ -21,12 +21,9 @@
 #include <iomanip>
 #include <fstream>
 #include <cstring>
+#include <gtkmm.h>
 
 #include "Configure.h"
-
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
 
 void CConfigure::SetDefaultValues()
 {
@@ -43,7 +40,8 @@ void CConfigure::SetDefaultValues()
 
 void CConfigure::ReadData()
 {
-	std::string path(CFG_DIR);
+        std::string path = Glib::get_user_config_dir() + G_DIR_SEPARATOR_S + "mvoice";
+	path.append(G_DIR_SEPARATOR_S);
 	path.append("mvoice.cfg");
 
 	std::ifstream cfg(path.c_str(), std::ifstream::in);
@@ -92,7 +90,8 @@ void CConfigure::ReadData()
 void CConfigure::WriteData()
 {
 
-	std::string path(CFG_DIR);
+	std::string path = Glib::get_user_config_dir() + G_DIR_SEPARATOR_S + "mvoice";
+	path.append(G_DIR_SEPARATOR_S);
 	path.append("mvoice.cfg");
 
 	// directory exists, now make the file

--- a/M17Gateway.cpp
+++ b/M17Gateway.cpp
@@ -24,12 +24,9 @@
 #include <iomanip>
 #include <fstream>
 #include <cstring>
+#include <gtkmm.h>
 
 #include "M17Gateway.h"
-
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
 
 CM17Gateway::CM17Gateway() : CBase()
 {
@@ -46,7 +43,8 @@ CM17Gateway::~CM17Gateway()
 bool CM17Gateway::Init(const CFGDATA &cfgdata)
 {
 	mlink.state = ELinkState::unlinked;
-	std::string path(CFG_DIR);
+	std::string path = Glib::get_user_config_dir() + G_DIR_SEPARATOR_S + "mvoice";
+	path.append(G_DIR_SEPARATOR_S);
 	path.append("qn.db");
 	if (AM2M17.Open("am2m17"))
 		return true;

--- a/M17RouteMap.cpp
+++ b/M17RouteMap.cpp
@@ -18,13 +18,10 @@
 
 #include <fstream>
 #include <regex>
+#include <gtkmm.h>
 
 #include "M17RouteMap.h"
 #include "Utilities.h"
-
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
 
 CM17RouteMap::~CM17RouteMap()
 {
@@ -88,7 +85,8 @@ void CM17RouteMap::ReadJson(const char *filename)
 	bool cs, ur, v4, v6, po;
 	cs = ur = v4 = v6 = po = false;
 	std::string scs, sur, sv4, sv6, spo;
-	std::string path(CFG_DIR);
+	std::string path = Glib::get_user_config_dir() + G_DIR_SEPARATOR_S + "mvoice";
+	path.append(G_DIR_SEPARATOR_S);
 	path.append(filename);
 	std::ifstream f(path, std::ifstream::in);
 	while (f.good()) {
@@ -135,7 +133,8 @@ void CM17RouteMap::ReadJson(const char *filename)
 
 void CM17RouteMap::Read(const char *filename)
 {
-	std::string path(CFG_DIR);
+	std::string path = Glib::get_user_config_dir() + G_DIR_SEPARATOR_S + "mvoice";
+	path.append(G_DIR_SEPARATOR_S);
 	path.append(filename);
 	std::ifstream file(path, std::ifstream::in);
 	if (file.is_open()) {
@@ -153,7 +152,8 @@ void CM17RouteMap::Read(const char *filename)
 
 void CM17RouteMap::Save() const
 {
-	std::string path(CFG_DIR);
+	std::string path = Glib::get_user_config_dir() + G_DIR_SEPARATOR_S + "mvoice";
+	path.append(G_DIR_SEPARATOR_S);
 	path.append("M17Hosts.cfg");
 	std::ofstream file(path.c_str(), std::ofstream::out | std::ofstream::trunc);
 	if (file.is_open()) {

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -33,10 +33,6 @@
 #include "Utilities.h"
 #include "TemplateClasses.h"
 
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
-
 static Glib::RefPtr<Gtk::Application> theApp;
 
 CMainWindow::CMainWindow() :
@@ -108,7 +104,8 @@ void CMainWindow::CloseAll()
 
 bool CMainWindow::Init(const Glib::RefPtr<Gtk::Builder> builder, const Glib::ustring &name)
 {
-	std::string dbname(CFG_DIR);
+	std::string dbname = Glib::get_user_config_dir() + G_DIR_SEPARATOR_S + "mvoice";
+	dbname.append(G_DIR_SEPARATOR_S);
 	dbname.append("qn.db");
 
 	if (M172AM.Open("m172am")) {
@@ -581,7 +578,8 @@ static void ReadM17Json()
 {
 	curl_global_init(CURL_GLOBAL_ALL);
 
-	std::string path(CFG_DIR);
+	std::string path = Glib::get_user_config_dir() + G_DIR_SEPARATOR_S + "mvoice";
+	path.append(G_DIR_SEPARATOR_S);
 	path.append("m17refl.json");
 	std::ofstream ofs(path);
 	if (ofs.is_open()) {
@@ -600,6 +598,9 @@ static void ReadM17Json()
 
 int main (int argc, char **argv)
 {
+        // Define a standard place for config files
+        std::string path = Glib::get_user_config_dir() + G_DIR_SEPARATOR_S + "mvoice";
+        g_mkdir_with_parents(path.c_str(), S_IRWXU);
 	ReadM17Json();
 
 	theApp = Gtk::Application::create(argc, argv, "net.openquad.DVoice");
@@ -608,13 +609,15 @@ int main (int argc, char **argv)
 	Glib::RefPtr<Gtk::Builder> builder = Gtk::Builder::create();
 	try
 	{
-		std::string path(CFG_DIR);
-		builder->add_from_file(path + "MVoice.glade");
+	        builder->add_from_file(path + G_DIR_SEPARATOR_S + "MVoice.glade");
 	}
 	catch (const Glib::FileError& ex)
 	{
-		std::cerr << "FileError: " << ex.what() << std::endl;
-		return 1;
+	        if (0 == builder->add_from_resource("/n7tae/mvoice/MVoice.glade"))
+		  {
+		    std::cerr << "FileError: " << ex.what() << std::endl;
+		    return 1;
+		  }
 	}
 	catch (const Glib::MarkupError& ex)
 	{

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 # Copyright (c) 2019-2021 by Thomas A. Early N7TAE
-CFGDIR = $(HOME)/etc/
+CFGDIR = $(HOME)/.config/mvoice
 BINDIR = $(HOME)/bin/
 
 # choose this if you want debugging help
-#CPPFLAGS=-ggdb -W -Wall -std=c++11 -Icodec2 -DCFG_DIR=\"$(CFGDIR)\" `pkg-config --cflags gtkmm-3.0`
+#CPPFLAGS=-ggdb -W -Wall -std=c++11 -Icodec2 `pkg-config --cflags gtkmm-3.0`
 # or, you can choose this for a smaller executable without debugging help
-CPPFLAGS=-W -Wall -std=c++11 -Icodec2 -DCFG_DIR=\"$(CFGDIR)\" `pkg-config --cflags gtkmm-3.0`
+CPPFLAGS=-W -Wall -std=c++11 -Icodec2 `pkg-config --cflags gtkmm-3.0`
 
 EXE = mvoice
-SRCS = $(wildcard *.cpp) $(wildcard codec2/*.cpp)
+SRCS = $(wildcard *.cpp) $(wildcard codec2/*.cpp) resources.cpp
 OBJS = $(SRCS:.cpp=.o)
 DEPS = $(SRCS:.cpp=.d)
 
@@ -17,6 +17,10 @@ $(EXE) : $(OBJS)
 
 %.o : %.cpp MVoice.glade
 	g++ $(CPPFLAGS) -MMD -MD -c $< -o $@
+
+resources.cpp: mvoice.gresources.xml
+	glib-compile-resources mvoice.gresources.xml \
+        --target=resources.cpp --generate-source
 
 .PHONY : clean
 

--- a/mvoice.gresources.xml
+++ b/mvoice.gresources.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/n7tae/mvoice/">
+    <file preprocess="xml-stripblanks" compressed="true">MVoice.glade</file>
+  </gresource>
+</gresources>


### PR DESCRIPTION
Hello!
Some tidying up making use of Gtk features.

Using Glib::get_user_config_dir() to put the mvoice config files in the right place on the platform.
Use Gtk resource for a default glade configuration if MVoice.glade is not available.

Add a CMake build for modern C++ cross-platform building.

I hope you find these changes useful.
-Maitland
