### PR TITLE
Aa4hs/better config

### DIFF
--- a/AudioManager.cpp
+++ b/AudioManager.cpp
@@ -30,10 +30,6 @@
 #include "codec2.h"
 #include "Callsign.h"
 
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
-
 CAudioManager::CAudioManager() : hot_mic(false), play_file(false), m17_sid_in(0U)
 {
 	link_open = true;
@@ -59,7 +55,6 @@ CAudioManager::CAudioManager() : hot_mic(false), play_file(false), m17_sid_in(0U
 bool CAudioManager::Init(CMainWindow *pMain)
 {
 	pMainWindow = pMain;
-	std::string index(CFG_DIR);
 
 	AM2M17.SetUp("am2m17");
 	LogInput.SetUp("log_input");

--- a/Configure.cpp
+++ b/Configure.cpp
@@ -24,9 +24,7 @@
 
 #include "Configure.h"
 
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
+extern char *mvoice_cfg_dir;
 
 void CConfigure::SetDefaultValues()
 {
@@ -44,7 +42,7 @@ void CConfigure::SetDefaultValues()
 void CConfigure::ReadData()
 {
 	SetDefaultValues();
-	std::string path(CFG_DIR);
+	std::string path(mvoice_cfg_dir);
 	path.append("mvoice.cfg");
 
 	std::ifstream cfg(path.c_str(), std::ifstream::in);
@@ -93,7 +91,7 @@ void CConfigure::ReadData()
 void CConfigure::WriteData()
 {
 
-	std::string path(CFG_DIR);
+	std::string path(mvoice_cfg_dir);
 	path.append("mvoice.cfg");
 
 	// directory exists, now make the file

--- a/M17Gateway.cpp
+++ b/M17Gateway.cpp
@@ -27,9 +27,7 @@
 
 #include "M17Gateway.h"
 
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
+extern char *mvoice_cfg_dir;
 
 CM17Gateway::CM17Gateway() : CBase()
 {
@@ -56,7 +54,7 @@ void CM17Gateway::ReleaseLock()
 bool CM17Gateway::Init(const CFGDATA &cfgdata)
 {
 	mlink.state = ELinkState::unlinked;
-	std::string path(CFG_DIR);
+	std::string path(mvoice_cfg_dir);
 	path.append("qn.db");
 	if (AM2M17.Open("am2m17"))
 		return true;

--- a/M17RouteMap.cpp
+++ b/M17RouteMap.cpp
@@ -22,9 +22,7 @@
 #include "M17RouteMap.h"
 #include "Utilities.h"
 
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
+extern char *mvoice_cfg_dir;
 
 CM17RouteMap::~CM17RouteMap()
 {
@@ -88,7 +86,7 @@ void CM17RouteMap::ReadJson(const char *filename)
 	bool cs, ur, v4, v6, po;
 	cs = ur = v4 = v6 = po = false;
 	std::string scs, sur, sv4, sv6, spo;
-	std::string path(CFG_DIR);
+	std::string path(mvoice_cfg_dir);
 	path.append(filename);
 	std::ifstream f(path, std::ifstream::in);
 	while (f.good()) {
@@ -135,7 +133,7 @@ void CM17RouteMap::ReadJson(const char *filename)
 
 void CM17RouteMap::Read(const char *filename)
 {
-	std::string path(CFG_DIR);
+	std::string path(mvoice_cfg_dir);
 	path.append(filename);
 	std::ifstream file(path, std::ifstream::in);
 	if (file.is_open()) {
@@ -153,7 +151,7 @@ void CM17RouteMap::Read(const char *filename)
 
 void CM17RouteMap::Save() const
 {
-	std::string path(CFG_DIR);
+	std::string path(mvoice_cfg_dir);
 	path.append("M17Hosts.cfg");
 	std::ofstream file(path.c_str(), std::ofstream::out | std::ofstream::trunc);
 	if (file.is_open()) {

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -33,9 +33,7 @@
 #include "Utilities.h"
 #include "TemplateClasses.h"
 
-#ifndef CFG_DIR
-#define CFG_DIR "/tmp/"
-#endif
+char *mvoice_cfg_dir;
 
 static void MyIdleProcess(void *p)
 {
@@ -130,7 +128,7 @@ bool CMainWindow::Init()
 		{ 0,             0, 0,                                     0, 0, 0, 0, 0, 0 }
 	};
 
-	std::string iconpath(CFG_DIR);
+	std::string iconpath(mvoice_cfg_dir);
 	iconpath.append("mvoice48.png");
 	pIcon = new Fl_PNG_Image(iconpath.c_str());
 
@@ -870,7 +868,7 @@ static void ReadM17Json()
 {
 	curl_global_init(CURL_GLOBAL_ALL);
 
-	std::string path(CFG_DIR);
+	std::string path(mvoice_cfg_dir);
 	path.append("m17refl.json");
 	std::ofstream ofs(path);
 	if (ofs.is_open()) {
@@ -889,8 +887,13 @@ static void ReadM17Json()
 
 int main (int argc, char **argv)
 {
-	ReadM17Json();
+#ifdef CFG_DIR
+	mvoice_cfg_dir = (char *) CFG_DIR;
+#else
+	mvoice_cfg_dir = (char *) "/tmp/";
+#endif
 
+	ReadM17Json();
 	CMainWindow MainWindow;
 	if (MainWindow.Init())
 		return 1;

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -29,6 +29,8 @@
 #include <chrono>
 #include <cmath>
 
+#include <FL/Fl_Preferences.H>
+#include <FL/filename.H>
 #include "MainWindow.h"
 #include "Utilities.h"
 #include "TemplateClasses.h"
@@ -892,6 +894,16 @@ int main (int argc, char **argv)
 #else
 	mvoice_cfg_dir = (char *) "/tmp/";
 #endif
+	// Use FLTK to locate mvoice config files.
+	Fl_Preferences prefs( Fl_Preferences::USER, "n7tae", "mvoice" );
+	char path[FL_PATH_MAX];
+	if (prefs.getUserdataPath(path,FL_PATH_MAX)) {
+		std::string iconpath(path);
+		iconpath.append("mvoice48.png");
+		std::ifstream testicon;
+		testicon.open(iconpath);
+		if (testicon) mvoice_cfg_dir=path;
+	}
 
 	ReadM17Json();
 	CMainWindow MainWindow;


### PR DESCRIPTION
The compile-time setting of CFG_DIR is crufty - since the ~ expansion is fragile.
Refactoring to mvoice_cfg_dir and  having main() as the one place to set it allows us to have main() process environment variables or command-line arguments to set it in the future.
But, since it is now FTLK, maybe use Fl_Preferences.
(FLTK < 1.4 uses ~/.fltk/... but newest FLTK will use ~/.config/... and honor $XDG_CONFIG_HOME)

Extra logic ignores the Fl_Preferences path if the mvoice48.png file is not found there. Falling back to
compiled-in defaults.
