### PR TITLE
Make more strings translatable

### DIFF
--- a/AboutDlg.cpp
+++ b/AboutDlg.cpp
@@ -36,11 +36,11 @@ bool CAboutDlg::Init(Fl_PNG_Image *pIcon)
 	pIconBox = new Fl_Box(176, 30, 48, 48);
 	pIconBox->image(pIcon);
 
-	snprintf(version, sizeof(version), "MVoice version # %s", VERSION);
+	snprintf(version, sizeof(version), _("MVoice version # %s"), VERSION);
 
 	pVersionBox = new Fl_Box(0, 100, 400, 30, version);
 
-	pCopyrightBox = new Fl_Box(0, 150, 400, 30, "Copyright (c) 2022 by Thomas A. Early N7TAE");
+	pCopyrightBox = new Fl_Box(0, 150, 400, 30, _("Copyright (c) 2022 by Thomas A. Early N7TAE"));
 
 	pDlg->end();
 	pDlg->callback(&CAboutDlg::WindowCallbackCB, this);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -250,7 +250,7 @@ bool CMainWindow::Init()
 	pModuleGroup->end();
 	pModuleRadioButton[0]->setonly();
 
-	pActionButton = new Fl_Button(50, 475, 100, 30, "Action");
+	pActionButton = new Fl_Button(50, 475, 100, 30, _("Action"));
 	pActionButton->tooltip(_("Update or delete an existing contact, or save a new contact"));
 	pActionButton->labelsize(16);
 	pActionButton->deactivate();

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -269,7 +269,7 @@ bool CMainWindow::Init()
 	pConnectButton->callback(&CMainWindow::LinkButtonCB, this);
 
 	pDisconnectButton = new Fl_Button(455, 475, 100, 30, _("Disconnect"));
-	pDisconnectButton->tooltip(_("Disconnected from a reflector"));
+	pDisconnectButton->tooltip(_("Disconnect from an M17 reflector"));
 	pDisconnectButton->labelsize(16);
 	pDisconnectButton->deactivate();
 	pDisconnectButton->callback(&CMainWindow::UnlinkButtonCB, this);

--- a/SettingsDlg.cpp
+++ b/SettingsDlg.cpp
@@ -94,7 +94,7 @@ void CSettingsDlg::SaveWidgetStates(CFGDATA &d)
 	{
 		d.sAudioIn.assign(itin->second.first);
 	}
-	const std::string out(pAudioInputChoice->text());
+	const std::string out(pAudioOutputChoice->text());
 	auto itout = AudioOutMap.find(out);
 	if (AudioOutMap.end() != itout)
 	{

--- a/SettingsDlg.cpp
+++ b/SettingsDlg.cpp
@@ -208,7 +208,7 @@ bool CSettingsDlg::Init(CMainWindow *pMain)
 
 	//////////////////////////////////////////////////////////////////////////
 	pAudioGroup = new Fl_Group(20, 30, 410, 210, _("Audio"));
-	pAudioGroup->tooltip(_("Select the audio Input device"));
+	pAudioGroup->tooltip(_("Select the audio Input and Output devices"));
 	pAudioGroup->labelsize(16);
 
 	pAudioInputChoice = new Fl_Choice(135, 50, 260, 24, _("Input:"));


### PR DESCRIPTION
This PR adds the `_( )` macro around some strings to make them tanslatable.