### PR TITLE
care for non "abstract unix domain socket" supported OS

### DIFF
--- a/UnixDgramSocket.h
+++ b/UnixDgramSocket.h
@@ -21,6 +21,10 @@
 #include <stdlib.h>
 #include <sys/un.h>
 
+#if !defined(__linux__)
+#define USE_NAMED_SOCKET
+#endif
+
 class CUnixDgramReader
 {
 public:
@@ -32,6 +36,9 @@ public:
 	int GetFD();
 private:
 	int fd;
+#ifdef USE_NAMED_SOCKET
+	std::string socket_path;
+#endif
 };
 
 class CUnixDgramWriter


### PR DESCRIPTION
UnixDgramSocket.cpp uses abstract unix domain socket, this is Linux extension.
Here is an idea for other OSes, but currently there is no care for unexpected program termination such as caused by signals (if it occurs, /tmp.mvoice-xxxx.sock is not deleted).