### PR TITLE
add #include <libintl.h> to use gettext()

### DIFF
--- a/AboutDlg.cpp
+++ b/AboutDlg.cpp
@@ -21,6 +21,7 @@
 
 #include "AboutDlg.h"
 
+#include <libintl.h>
 #define _(STRING) gettext(STRING)
 
 #define VERSION "1.3.9"

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -42,6 +42,7 @@
 #include "dht-values.h"
 #endif
 
+#include <libintl.h>
 #define _(STRING) gettext(STRING)
 //#define BOOTFILENAME "DHTNodes.bin"
 

--- a/SMSDlg.cpp
+++ b/SMSDlg.cpp
@@ -23,6 +23,7 @@
 #include "SMSDlg.h"
 #include "Utilities.h"
 
+#include <libintl.h>
 #define _(STRING) gettext(STRING)
 
 CSMSDlg::CSMSDlg() : pMainWindow(nullptr), pDlg(nullptr) {}

--- a/SettingsDlg.cpp
+++ b/SettingsDlg.cpp
@@ -25,6 +25,7 @@
 #include "SettingsDlg.h"
 #include "MainWindow.h"
 
+#include <libintl.h>
 #define _(STRING) gettext(STRING)
 
 static const char *notfoundstr = _(" not found");


### PR DESCRIPTION
Linux does not require #include <libintl.h> to use gettext(), but including this header is recommended.
